### PR TITLE
Update ttyd.service

### DIFF
--- a/debian/ttyd.service
+++ b/debian/ttyd.service
@@ -9,7 +9,7 @@ After=network.target
 Type=simple
 PermissionsStartOnly=true
 EnvironmentFile=/etc/default/ttyd
-ExecStart=/usr/bin/ttyd -i ${INTERFACE} -p ${PORT} -u ${UID} -g ${GID} ${EXTRA_ARGS} ${COMMAND}
+ExecStart=/usr/bin/ttyd -i ${INTERFACE} -p ${PORT} -u ${UID} -g ${GID} $EXTRA_ARGS ${COMMAND}
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
Removed {} from EXTRA_ARGS since this causes the command to be escaped using '' and is then seen by ttyd as one single parameter. This fails if you add "-d 7 --ssl --ssl-cert server.crt --ssl-key server.key" for example.